### PR TITLE
Support Pixi v7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "author": "David S. Figatner",
     "license": "MIT",
     "peerDependencies": {
-        "pixi.js": "^6.0.0"
+        "pixi.js": "^6.0.0 || ^7.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.13.14",


### PR DESCRIPTION
This extends the range to support Pixi 7 versions. I've tested it locally and reviewed the code to ensure there shouldn't be any incompatibilities. 